### PR TITLE
Fix typo in readme regarding SaaS listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Doit-Easily
 
-Doit-Easily is the [backend integrations][1] required for a GCP marketplace SaaS Offering.
+Doit-Easily is the [backend integrations][1] required for a GCP marketplace listing.
 
 ## Architectural diagram
 


### PR DESCRIPTION
See change, doit-easily is not exclusively for SaaS listings.