### PR TITLE
Remove premature reference to Cloud Run service

### DIFF
--- a/docs/terraform/setup/iam.tf
+++ b/docs/terraform/setup/iam.tf
@@ -61,15 +61,6 @@ resource "google_project_iam_member" "doit_easily_pubsub_editor" {
   role    = "roles/pubsub.editor"
 }
 
-#allow the doit-easily SA to invoke the cloudrun app
-resource "google_cloud_run_service_iam_member" "doit_easily_cloudrun_invoker" {
-  member  = "serviceAccount:${google_service_account.doit_easily_backend_integration_sa.email}"
-  project = var.project_id
-  role    = "roles/run.invoker"
-  service = google_cloud_run_service.doit_easily_cloudrun_service.name
-  location = var.cloudrun_location
-}
-
 #the SA used for the saas-codelab
 resource "google_service_account" "saas_codelab_backend_integration_sa" {
   account_id = "saas-codelab"


### PR DESCRIPTION
The IAM resource referenced a Cloud Run service created just on a future step, causing issues on fresh projects.