### PR TITLE
Update deprecated config

### DIFF
--- a/docs/terraform/app_deploy/app.tf
+++ b/docs/terraform/app_deploy/app.tf
@@ -59,7 +59,7 @@ resource "google_secret_manager_secret" "settings_toml" {
   project = var.project_id
   secret_id = "settings-toml"
   replication {
-    automatic = true
+    auto {}
   }
 }
 


### PR DESCRIPTION
Resolves a deprecation error:
```
│ Warning: Argument is deprecated
│ 
│   with google_secret_manager_secret.settings_toml,
│   on app.tf line 62, in resource "google_secret_manager_secret" "settings_toml":
│   62:     automatic = true
│ 
│ `automatic` is deprecated and will be removed in a future major release. Use `auto` instead.
│ 
│ (and one more similar warning elsewhere)
```