### PR TITLE
Add missing permission. cloud-commerce-producer needs configEditor

### DIFF
--- a/docs/terraform/setup/iam.tf
+++ b/docs/terraform/setup/iam.tf
@@ -12,6 +12,12 @@ resource "google_project_iam_member" "cloud-commerce-marketplace_admin" {
   role    = "roles/servicemanagement.admin"
 }
 
+resource "google_project_iam_member" "cloud-commerce-produer-config-editor" {
+  project = google_project.gcp-marketplace-public.id
+  member  = "serviceAccount:cloud-commerce-producer@system.gserviceaccount.com"
+  role    = "roles/servicemanagement.configEditor"
+}
+
 #give google access to this project
 resource "google_project_iam_member" "cloud-commerce-procurement_admin" {
   project = google_project.isv-public.id


### PR DESCRIPTION
Looks like IAM config was missing. 

From official doc
> To the service account cloud-commerce-producer@system.gserviceaccount.com, grant the Config Editor (roles/servicemanagement.configEditor) role.

https://cloud.google.com/marketplace/docs/partners/integrated-saas/set-up-environment