### PR TITLE
Add an SSL policy with minimum TLS version 1.2

### DIFF
--- a/docs/terraform/app_deploy/loadbalancer.tf
+++ b/docs/terraform/app_deploy/loadbalancer.tf
@@ -34,6 +34,13 @@ resource "google_compute_url_map" "url_map" {
   }
 }
 
+resource "google_compute_ssl_policy" "ssl_policy_modern_tls12" {
+  project         = var.project_id
+  name            = "ssl-policy-modern-tls12"
+  profile         = "MODERN"
+  min_tls_version = "TLS_1_2"
+}
+
 module "api-lb" {
   source  = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
   version = "~> 6.3"
@@ -47,6 +54,7 @@ module "api-lb" {
   url_map                         = google_compute_url_map.url_map.self_link
   create_url_map = false
   address                         = google_compute_global_address.external_ip.address
+  ssl_policy                      = google_compute_ssl_policy.ssl_policy_modern_tls12.self_link
   create_address                  = false
   backends = {
     default = {


### PR DESCRIPTION
## Summary
This PR introduces a GCP SSL Policy that enforces a minimum TLS version of 1.2 to enhance security and compliance.

## Why?
Many organizations have strict security policies requiring the use of TLS 1.2 or higher to mitigate vulnerabilities associated with older versions. This update helps ensure compliance with security best practices.